### PR TITLE
updated the test to relax the number of spaces it expects

### DIFF
--- a/helpers/apps.go
+++ b/helpers/apps.go
@@ -70,7 +70,7 @@ func InstancesRunning(appName string, instances int, timeout time.Duration) {
 	Eventually(func() string {
 		return string(cf.Cf("app", appName).Wait(timeout).Out.Contents())
 	}, timeout*2, 2*time.Second).
-		Should(ContainSubstring(fmt.Sprintf("instances: %d/%d", instances, instances)))
+		Should(MatchRegexp(fmt.Sprintf("instances:\\s+%d/%d", instances, instances)))
 }
 
 func PushApp(appName, asset, buildpackName, domain string, timeout time.Duration, memoryLimit string) {


### PR DESCRIPTION
The CF CLI is displaying the instance information in a more user friendly way. As a result, the number of spacing has changed.

This PR is time sensitive because these changes need to make their way into the next cf-release (this repo is vendored into cf-acceptance-tests). Otherwise the next release of the CF CLI will break CATs. I'm working with release-integration to coordinate the timing. Y'all don't need to worry about that.