### PR TITLE
Address gosec rule G403

### DIFF
--- a/tls/certificates.go
+++ b/tls/certificates.go
@@ -10,10 +10,9 @@ import (
 	"encoding/pem"
 	"io"
 	"math/big"
+	"net"
 	"os"
 	"time"
-
-	"net"
 
 	. "github.com/onsi/gomega"
 )
@@ -71,7 +70,7 @@ func mapToX509Cert(PemEncodedCertFilePath string) []*x509.Certificate {
 }
 
 func buildCaFile() (string, *rsa.PrivateKey, error) {
-	privKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return "", nil, err
 	}
@@ -115,7 +114,6 @@ func buildCaFile() (string, *rsa.PrivateKey, error) {
 		Type:  "CERTIFICATE",
 		Bytes: caCert,
 	})
-
 	if err != nil {
 		return "", nil, err
 	}


### PR DESCRIPTION
Summary
---------------
This PR address gosec rule G403 stating RSA keys should be at least 2048 bits


Backward Compatibility
---------------
Breaking Change? **No**
