### PR TITLE
Fix issue with import path for this library

### DIFF
--- a/helpers/orgs.go
+++ b/helpers/orgs.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 
-	"github.com/cloudfoundry/cf-routing-test-helpers/schema"
+	"code.cloudfoundry.org/cf-routing-test-helpers/schema"
 	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
 )
 

--- a/helpers/routes.go
+++ b/helpers/routes.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 
-	"github.com/cloudfoundry/cf-routing-test-helpers/schema"
+	"code.cloudfoundry.org/cf-routing-test-helpers/schema"
 	"github.com/cloudfoundry/cf-test-helpers/v2/cf"
 )
 
@@ -153,13 +153,13 @@ func UpdateTCPPort(appName string, externalPort uint16, internalPorts []uint16, 
 	err := json.Unmarshal(cfResponse, &response)
 	Expect(err).NotTo(HaveOccurred())
 
-	destinations := []schema.RouteDestination{}
+	destinations := []schema.Destination{}
 	for _, port := range internalPorts {
 		for _, app := range response.Resources[0].Destinations {
-			destinations = append(destinations, schema.RouteDestination{
-				App: schema.AppResource{
+			destinations = append(destinations, schema.Destination{
+				App: schema.App{
 					Guid:    app.App.Guid,
-					Process: schema.AppProcessResource{Type: "web"},
+					Process: schema.Process{Type: "web"},
 				},
 				Port:     port,
 				Protocol: "tcp",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -4,13 +4,16 @@ type Metadata struct {
 	Guid string
 }
 
-type Resource struct {
-	Metadata Metadata
+type ListResponse struct {
+	Pagination Pagination
+	Resources  []List
 }
 
-type ListResponse struct {
+type List struct {
+	Guid string
+}
+type Pagination struct {
 	TotalResults int `json:"total_results"`
-	Resources    []Resource
 }
 
 type AppResource struct {
@@ -37,7 +40,41 @@ type RouteResource struct {
 }
 
 type OrgResource struct {
-	Entity struct {
-		QuotaDefinitionUrl string `json:"quota_definition_url"`
-	}
+	Resources []Org
+}
+type Org struct {
+	Guid  string
+	Links Links
+}
+type Links struct {
+	Quota Quota
+}
+type Quota struct {
+	Href string
+}
+
+type DomainResponse struct {
+	Resources []Domain
+}
+type Domain struct {
+	Guid string
+}
+type RouteObject struct {
+	Resources []Route
+}
+type Route struct {
+	Guid         string        `json:"guid"`
+	Destinations []Destination `json:"destinations"`
+}
+type Destination struct {
+	App      App    `json:"app"`
+	Port     uint16 `json:"port"`
+	Protocol string `json:"protocol"`
+}
+type App struct {
+	Guid    string  `json:"guid"`
+	Process Process `json:"process"`
+}
+type Process struct {
+	Type string `json:"type"`
 }


### PR DESCRIPTION
use `code.cloudfoundry.org` import path. This will remove the need to vendor this library under routing-release's go.mod.